### PR TITLE
Remove Autocomplete from Typeahead

### DIFF
--- a/src/components/grid-item/grid-item.vue
+++ b/src/components/grid-item/grid-item.vue
@@ -18,7 +18,7 @@
     div.mb-5.pd-grid-item
         .border.border-light.mb-3.position-relative
             .pd-grid-badge.bg-primary.text-white.text-truncate(v-text='badge', v-if="badge", :title="badge")
-            img.image(:style='`background-image:url(${image})`', src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
+            img.image(:style='`background-image:url(${image})`', :alt='title', src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==")
             slot(name="image")
         slot
             p(v-text='title')

--- a/src/components/typeahead/typeahead.vue
+++ b/src/components/typeahead/typeahead.vue
@@ -226,6 +226,7 @@
                 button.close.ml-3(type='button', aria-label='Remove', @click="removeFromResults(key)")
                     span.text-white(aria-hidden='true') &times;
             input.border-0.ml-1(
+                autocomplete="off",
                 :id="id",
                 ref="input",
                 type="text",


### PR DESCRIPTION
- Prevent browser from trying to autocomplete on type ahead obscuring results
- Add title to grid-item image (Usability enhancement)